### PR TITLE
Fix index tensor device mismatch by moving to CPU

### DIFF
--- a/src/dxtb/_src/scf/unrolling/default.py
+++ b/src/dxtb/_src/scf/unrolling/default.py
@@ -181,7 +181,7 @@ class SelfConsistentFieldFull(BaseTSCF):
                     break
 
                 # save all necessary variables for converged system
-                iconv = idxs[conv]
+                iconv = idxs[conv.cpu()]
                 q_converged[iconv, :mpdim, :norb] = q[conv, ..., :]
                 ch[iconv, :norb, :norb] = self._data.hamiltonian[conv, :, :]
                 cevecs[iconv, :norb, :norb] = self._data.evecs[conv, :, :]
@@ -247,7 +247,7 @@ class SelfConsistentFieldFull(BaseTSCF):
 
                 # cull local variables
                 q = q[~conv, :mpdim, :norb]
-                idxs = idxs[~conv]
+                idxs = idxs[~conv.cpu()]
 
                 if self._data.charges["mono"] is not None:
                     self._data.charges["mono"] = torch.Size(


### PR DESCRIPTION
## Description

This PR ensures the index tensor is sent to the CPU for full unrolling SCF mode during batched computations on a CUDA device. The tensor `conv = self.mixer.converged` may be a CUDA tensor as it is derived from deltas in the mixer class:

https://github.com/grimme-lab/dxtb/blob/92a7e77c682a14da34aedf0eec9c64193685db1b/src/dxtb/_src/scf/unrolling/default.py#L173-L184

https://github.com/grimme-lab/dxtb/blob/92a7e77c682a14da34aedf0eec9c64193685db1b/src/dxtb/_src/scf/mixer/base.py#L146-L166

Fixes #194.