### PR TITLE
Disable timer by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ With *dxtb*, we provide a re-implementation of the xTB methods in PyTorch, which
 pip install dxtb[libcint]
 ```
 
-Installing the libcint interface is highly recommended, as it is significantly faster than the pure PyTorch implementation and provides access to higher-order multipole integrals and their derivatives.
+Installing the libcint interface is highly recommended, as it is significantly faster than the pure PyTorch implementation and provides access to higher-order multipole integrals and their derivatives (**required for GFN2-xTB**).
 However, the interface is currently only available on Linux.
 
 ### conda <a href="https://anaconda.org/conda-forge/dxtb"><img src="https://img.shields.io/conda/vn/conda-forge/dxtb.svg" alt="Conda Version"></a> <a href="https://anaconda.org/conda-forge/dxtb"><img src="https://img.shields.io/conda/dn/conda-forge/dxtb?style=flat&color=orange" alt="Conda Downloads"></a>

--- a/src/dxtb/__init__.py
+++ b/src/dxtb/__init__.py
@@ -27,7 +27,7 @@ from dxtb._src.timing import timer, kill_timer
 
 from os import getenv
 
-if getenv("DXTB_TIMER", "False").lower() in ("true", "1", "yes") is False:
+if getenv("DXTB_TIMER", "False").lower() not in ("true", "1", "yes", "on"):
     timer.disable()
 del getenv
 

--- a/src/dxtb/__init__.py
+++ b/src/dxtb/__init__.py
@@ -24,6 +24,14 @@ A fully differentiable extended tight-binding package.
 # import timer first to get correct total time
 from dxtb._src.timing import timer, kill_timer
 
+
+from os import getenv
+
+if getenv("DXTB_TIMER", "False").lower() in ("true", "1", "yes") is False:
+    timer.disable()
+del getenv
+
+
 timer.start("Import")
 timer.start("PyTorch", parent_uid="Import")
 import torch

--- a/src/dxtb/_src/calculators/types/base.py
+++ b/src/dxtb/_src/calculators/types/base.py
@@ -487,8 +487,16 @@ class BaseCalculator(GetPropertiesMixin, TensorLike):
         dtype : torch.dtype | None, optional
             Data type of the tensor. If ``None`` (default), the data type is
             inferred.
+        kwargs : Any
+            Additional keyword arguments.
+            - ``auto_int_level``: Automatically set the integral level based on
+              the parametrization. Defaults to ``True``. This should only be
+              turned off for testing purposes.
+            - ``timer``: Enable the timer. Defaults to ``False``. The global
+              timer can also be enabled by setting the environment variable
+              ``DXTB_TIMER`` to ``1``.
         """
-        if timer.enabled is False and kwargs.pop("timer", False):
+        if not timer.enabled and kwargs.pop("timer", False):
             timer.enable()
 
         timer.start("Calculator", parent_uid="Setup")

--- a/src/dxtb/_src/calculators/types/base.py
+++ b/src/dxtb/_src/calculators/types/base.py
@@ -488,6 +488,9 @@ class BaseCalculator(GetPropertiesMixin, TensorLike):
             Data type of the tensor. If ``None`` (default), the data type is
             inferred.
         """
+        if timer.enabled is False and kwargs.pop("timer", False):
+            timer.enable()
+
         timer.start("Calculator", parent_uid="Setup")
 
         # setup verbosity first

--- a/src/dxtb/_src/cli/argparser.py
+++ b/src/dxtb/_src/cli/argparser.py
@@ -277,6 +277,14 @@ def parser(name: str = "dxtb", **kwargs: Any) -> argparse.ArgumentParser:
         help="R|Whether to use strict mode. Throws errors on warnings.",
     )
     p.add_argument(
+        "--timer",
+        action="store_true",
+        help=(
+            "R|Whether to enable the timer for the calculator. For the "
+            "global timer, set the environment variable 'DXTB_TIMER=1'."
+        ),
+    )
+    p.add_argument(
         "--efield",
         type=float,
         nargs=3,

--- a/src/dxtb/_src/cli/driver.py
+++ b/src/dxtb/_src/cli/driver.py
@@ -116,9 +116,11 @@ class Driver:
         return vals
 
     def singlepoint(self) -> Result | Tensor:
-        timer.start("Setup")
-
         args = self.args
+
+        if timer.enabled is False and args.timer is True:
+            timer.enable()
+        timer.start("Setup")
 
         # logging.basicConfig(
         # level=args.loglevel.upper(),

--- a/src/dxtb/_src/cli/driver.py
+++ b/src/dxtb/_src/cli/driver.py
@@ -223,7 +223,12 @@ class Driver:
 
         # setup calculator
         calc = Calculator(
-            numbers, par, opts=config, interaction=interactions, **dd
+            numbers,
+            par,
+            opts=config,
+            interaction=interactions,
+            **dd,
+            timer=args.timer,
         )
         timer.stop("Setup")
 


### PR DESCRIPTION
Timer will now be disabled. Can be enabled globally, by setting the environment variable `DXTB_TIMER=1` or, for the calculator, by passing `timer=True` as keyword argument during instantiation of the calculator.