### PR TITLE
Pydantic tensor serialization

### DIFF
--- a/src/dxtb/_src/calculators/types/base.py
+++ b/src/dxtb/_src/calculators/types/base.py
@@ -496,6 +496,8 @@ class BaseCalculator(GetPropertiesMixin, TensorLike):
               timer can also be enabled by setting the environment variable
               ``DXTB_TIMER`` to ``1``.
         """
+        self.parameters = par
+
         if not timer.enabled and kwargs.pop("timer", False):
             timer.enable()
 

--- a/src/dxtb/_src/param/base.py
+++ b/src/dxtb/_src/param/base.py
@@ -68,9 +68,6 @@ class Param(BaseModel):
     meta: Optional[Meta] = None
     """Descriptive data on the model."""
 
-    element: Dict[str, Element]
-    """Element specific parameter records."""
-
     hamiltonian: Optional[Hamiltonian] = None
     """Definition of the Hamiltonian, always required."""
 
@@ -83,14 +80,17 @@ class Param(BaseModel):
     charge: Optional[Charge] = None
     """Definition of the isotropic second-order charge interactions."""
 
+    thirdorder: Optional[ThirdOrder] = None
+    """Definition of the isotropic third-order charge interactions."""
+
     multipole: Optional[Multipole] = None
     """Definition of the anisotropic second-order multipolar interactions."""
 
     halogen: Optional[Halogen] = None
     """Definition of the halogen bonding correction."""
 
-    thirdorder: Optional[ThirdOrder] = None
-    """Definition of the isotropic third-order charge interactions."""
+    element: Dict[str, Element]
+    """Element specific parameter records."""
 
     solvation: Optional[Solvation] = None
     """Definition of the solvation model."""

--- a/src/dxtb/_src/param/charge.py
+++ b/src/dxtb/_src/param/charge.py
@@ -23,9 +23,13 @@ Definition of the isotropic second-order charge interactions.
 
 from __future__ import annotations
 
+from typing import Union
+
 from pydantic import BaseModel
 
 from dxtb._src.constants.xtb import DEFAULT_ES2_GEXP
+
+from .tensor import TensorPydantic
 
 __all__ = ["ChargeEffective", "Charge"]
 
@@ -36,7 +40,7 @@ class ChargeEffective(BaseModel):
     parametrization.
     """
 
-    gexp: float = DEFAULT_ES2_GEXP
+    gexp: Union[float, TensorPydantic] = DEFAULT_ES2_GEXP
     """Exponent of Coulomb kernel. """
 
     average: str = "harmonic"

--- a/src/dxtb/_src/param/dispersion.py
+++ b/src/dxtb/_src/param/dispersion.py
@@ -33,11 +33,11 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 from tad_dftd3 import defaults as d3_defaults
 from tad_dftd4 import defaults as d4_defaults
 
-from dxtb._src.typing import Tensor
+from .tensor import TensorPydantic
 
 __all__ = ["D3Model", "D4Model", "Dispersion"]
 
@@ -47,22 +47,20 @@ class D3Model(BaseModel):
     Representation of the DFT-D3(BJ) contribution for a parametrization.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    s6: Union[float, Tensor] = d3_defaults.S6
+    s6: Union[float, TensorPydantic] = d3_defaults.S6
     """Scaling factor for multipolar (dipole-dipole contribution) terms."""
 
-    s8: Union[float, Tensor] = d3_defaults.S8
+    s8: Union[float, TensorPydantic] = d3_defaults.S8
     """Scaling factor for multipolar (dipole-quadrupole contribution) terms."""
 
-    s9: Union[float, Tensor] = d3_defaults.S9
+    a1: Union[float, TensorPydantic] = d3_defaults.A1
+    """Becke-Johnson damping parameter."""
+
+    a2: Union[float, TensorPydantic] = d3_defaults.A2
+    """Becke-Johnson damping parameter."""
+
+    s9: Union[float, TensorPydantic] = d3_defaults.S9
     """Scaling factor for the many-body dispersion term (ATM/RPA-like)."""
-
-    a1: Union[float, Tensor] = d3_defaults.A1
-    """Becke-Johnson damping parameter."""
-
-    a2: Union[float, Tensor] = d3_defaults.A2
-    """Becke-Johnson damping parameter."""
 
 
 class D4Model(BaseModel):
@@ -70,31 +68,29 @@ class D4Model(BaseModel):
     Representation of the DFT-D4 contribution for a parametrization.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
     sc: bool = False
     """Whether the dispersion correctio is used self-consistently or not."""
 
-    s6: Union[float, Tensor] = d4_defaults.S6
+    s6: Union[float, TensorPydantic] = d4_defaults.S6
     """Scaling factor for multipolar (dipole-dipole contribution) terms"""
 
-    s8: Union[float, Tensor] = d4_defaults.S8
+    s8: Union[float, TensorPydantic] = d4_defaults.S8
     """Scaling factor for multipolar (dipole-quadrupole contribution) terms"""
 
-    s9: Union[float, Tensor] = d4_defaults.S9
+    a1: Union[float, TensorPydantic] = d4_defaults.A1
+    """Becke-Johnson damping parameter."""
+
+    a2: Union[float, TensorPydantic] = d4_defaults.A2
+    """Becke-Johnson damping parameter."""
+
+    s9: Union[float, TensorPydantic] = d4_defaults.S9
     """Scaling factor for the many-body dispersion term (ATM/RPA-like)."""
 
-    s10: Union[float, Tensor] = d4_defaults.S10
+    s10: Union[float, TensorPydantic] = d4_defaults.S10
     """Scaling factor for quadrupole-quadrupole term."""
 
-    alp: Union[float, Tensor] = d4_defaults.ALP
+    alp: Union[float, TensorPydantic] = d4_defaults.ALP
     """Exponent of zero damping function in the ATM term."""
-
-    a1: Union[float, Tensor] = d4_defaults.A1
-    """Becke-Johnson damping parameter."""
-
-    a2: Union[float, Tensor] = d4_defaults.A2
-    """Becke-Johnson damping parameter."""
 
 
 class Dispersion(BaseModel):

--- a/src/dxtb/_src/param/element.py
+++ b/src/dxtb/_src/param/element.py
@@ -24,9 +24,11 @@ species.
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Union
 
 from pydantic import BaseModel
+
+from .tensor import TensorPydantic
 
 __all__ = ["Element"]
 
@@ -36,21 +38,16 @@ class Element(BaseModel):
     Representation of the parameters for a species.
     """
 
-    zeff: float
-    """Effective nuclear charge used in repulsion."""
-
-    arep: float
-    """Repulsion exponent."""
-
-    ############################################################################
-
-    en: float
-    """Electronnegativity."""
-
     shells: List[str]
     """Included shells with principal quantum number and angular momentum."""
 
-    ngauss: List[int]
+    levels: Union[Union[List[float], TensorPydantic], TensorPydantic]
+    """Atomic level energies for each shell"""
+
+    slater: Union[List[float], TensorPydantic]
+    """Slater exponents of the STO-NG functions for each shell"""
+
+    ngauss: Union[List[int], TensorPydantic]
     """
     Number of primitive Gaussian functions used in the STO-NG expansion for
     each shell.
@@ -58,47 +55,52 @@ class Element(BaseModel):
 
     ############################################################################
 
-    levels: List[float]
-    """Atomic level energies for each shell"""
-
-    slater: List[float]
-    """Slater exponents of the STO-NG functions for each shell"""
-
-    refocc: List[float]
+    refocc: Union[List[float], TensorPydantic]
     """Reference occupation for each shell"""
 
-    kcn: List[float]
-    """CN dependent shift of the self energy for each shell"""
-
-    shpoly: List[float]
+    shpoly: Union[List[float], TensorPydantic]
     """Polynomial enhancement for Hamiltonian elements"""
+
+    kcn: Union[List[float], TensorPydantic]
+    """CN dependent shift of the self energy for each shell"""
 
     ############################################################################
 
-    gam: float
+    gam: Union[float, TensorPydantic]
     """Chemical hardness / Hubbard parameter."""
 
-    lgam: List[float]
+    lgam: Union[List[float], TensorPydantic]
     """Relative chemical hardness for each shell."""
 
-    gam3: float = 0.0
+    gam3: Union[float, TensorPydantic] = 0.0
     """Atomic Hubbard derivative."""
 
     ############################################################################
 
-    dkernel: float = 0.0
-    """Dipolar exchange-correlation kernel."""
+    zeff: Union[float, TensorPydantic]
+    """Effective nuclear charge used in repulsion."""
 
-    qkernel: float = 0.0
-    """Quadrupolar exchange-correlation kernel."""
-
-    mprad: float = 0.0
-    """Offset radius for the damping in the AES energy."""
-
-    mpvcn: float = 0.0
-    """Shift value in the damping in the AES energy. Only used if mprad != 0."""
+    arep: Union[float, TensorPydantic]
+    """Repulsion exponent."""
 
     ############################################################################
 
-    xbond: float = 0.0
+    xbond: Union[float, TensorPydantic] = 0.0
     """Halogen bonding strength."""
+
+    en: Union[float, TensorPydantic]
+    """Electronnegativity."""
+
+    ############################################################################
+
+    dkernel: Union[float, TensorPydantic] = 0.0
+    """Dipolar exchange-correlation kernel."""
+
+    qkernel: Union[float, TensorPydantic] = 0.0
+    """Quadrupolar exchange-correlation kernel."""
+
+    mprad: Union[float, TensorPydantic] = 0.0
+    """Offset radius for the damping in the AES energy."""
+
+    mpvcn: Union[float, TensorPydantic] = 0.0
+    """Shift value in the damping in the AES energy. Only used if mprad != 0."""

--- a/src/dxtb/_src/param/halogen.py
+++ b/src/dxtb/_src/param/halogen.py
@@ -24,7 +24,11 @@ Currently, only GFN1-xTB's classical halogen bond correction is defined.
 
 from __future__ import annotations
 
+from typing import Union
+
 from pydantic import BaseModel
+
+from .tensor import TensorPydantic
 
 __all__ = ["ClassicalHalogen", "Halogen"]
 
@@ -35,12 +39,12 @@ class ClassicalHalogen(BaseModel):
     correction for a parametrization.
     """
 
-    damping: float
+    damping: Union[float, TensorPydantic]
     """
     Damping factor of attractive contribution in Lennard-Jones-like potential.
     """
 
-    rscale: float
+    rscale: Union[float, TensorPydantic]
     """Global scaling factor for covalent radii of AX bond."""
 
 

--- a/src/dxtb/_src/param/hamiltonian.py
+++ b/src/dxtb/_src/param/hamiltonian.py
@@ -27,9 +27,11 @@ additional distance dependent function formed from the element parametrization.
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from pydantic import BaseModel
+
+from .tensor import TensorPydantic
 
 __all__ = ["Hamiltonian", "XTBHamiltonian"]
 
@@ -42,23 +44,23 @@ class XTBHamiltonian(BaseModel):
     self-energy and the distance polynomial.
     """
 
-    shell: Dict[str, float]
-    """Shell-pair dependent scaling factor for off-site blocks"""
-
-    kpair: Dict[str, float] = {}
-    """Atom-pair dependent scaling factor for off-site valence blocks"""
-
-    enscale: float
-    """Electronegativity scaling factor for off-site valence blocks"""
-
-    wexp: float
+    wexp: Union[float, TensorPydantic]
     """Exponent of the orbital exponent dependent off-site scaling factor"""
+
+    kpol: Union[float, TensorPydantic] = 2.0
+    """Scaling factor for polarization functions"""
+
+    enscale: Union[float, TensorPydantic]
+    """Electronegativity scaling factor for off-site valence blocks"""
 
     cn: Optional[str] = None
     """Local environment descriptor for shifting the atomic self-energies"""
 
-    kpol: float = 2.0
-    """Scaling factor for polarization functions"""
+    shell: Dict[str, Union[float, TensorPydantic]]
+    """Shell-pair dependent scaling factor for off-site blocks"""
+
+    kpair: Dict[str, Union[float, TensorPydantic]] = {}
+    """Atom-pair dependent scaling factor for off-site valence blocks"""
 
 
 class Hamiltonian(BaseModel):

--- a/src/dxtb/_src/param/multipole.py
+++ b/src/dxtb/_src/param/multipole.py
@@ -26,9 +26,9 @@ from __future__ import annotations
 
 from typing import Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
-from dxtb.typing import Tensor
+from .tensor import TensorPydantic
 
 __all__ = ["MultipoleDamped", "Multipole"]
 
@@ -39,21 +39,19 @@ class MultipoleDamped(BaseModel):
     for a parametrization.
     """
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    dmp3: Union[float, Tensor]
+    dmp3: Union[float, TensorPydantic]
     """Damping function for inverse quadratic contributions."""
 
-    dmp5: Union[float, Tensor]
+    dmp5: Union[float, TensorPydantic]
     """Damping function for inverse cubic contributions"""
 
-    kexp: Union[float, Tensor]
+    kexp: Union[float, TensorPydantic]
     """Exponent for the generation of the multipolar damping radii."""
 
-    shift: Union[float, Tensor]
+    shift: Union[float, TensorPydantic]
     """Shift for the generation of the multipolar damping radii."""
 
-    rmax: Union[float, Tensor]
+    rmax: Union[float, TensorPydantic]
     """Maximum radius for the multipolar damping radii (Eq. 29)."""
 
 

--- a/src/dxtb/_src/param/repulsion.py
+++ b/src/dxtb/_src/param/repulsion.py
@@ -24,9 +24,11 @@ used in GFN1-xTB and GFN2-xTB.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel
+
+from .tensor import TensorPydantic
 
 __all__ = ["EffectiveRepulsion", "Repulsion"]
 
@@ -36,13 +38,13 @@ class EffectiveRepulsion(BaseModel):
     Representation of the repulsion contribution for a parametrization.
     """
 
-    kexp: float
+    kexp: Union[float, TensorPydantic]
     """
     Scaling of the interatomic distance in the exponential damping function of
     the repulsion energy.
     """
 
-    klight: Optional[float] = None
+    klight: Optional[Union[float, TensorPydantic]] = None
     """
     Scaling of the interatomic distance in the exponential damping function of
     the repulsion energy for light elements, i.e., H and He (only GFN2).

--- a/src/dxtb/_src/param/solvation.py
+++ b/src/dxtb/_src/param/solvation.py
@@ -23,9 +23,11 @@ Definition of the isotropic third-order onsite correction.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel
+
+from .tensor import TensorPydantic
 
 __all__ = ["ALPB", "Solvation"]
 
@@ -45,10 +47,10 @@ class ALPB(BaseModel):
     by Lange (JCTC 2012, 8, 1999-2011).
     """
 
-    born_scale: float
+    born_scale: Union[float, TensorPydantic]
     """Scaling factor for Born radii."""
 
-    born_offset: float
+    born_offset: Union[float, TensorPydantic]
     """Offset parameter for Born radii integration."""
 
 

--- a/src/dxtb/_src/param/tensor.py
+++ b/src/dxtb/_src/param/tensor.py
@@ -1,0 +1,53 @@
+# This file is part of dxtb.
+#
+# SPDX-Identifier: Apache-2.0
+# Copyright (C) 2024 Grimme Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Parametrization: Tensor Type
+============================
+
+Tensor type that allows serialization in Pydantic models.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Type
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+from dxtb.typing import Tensor
+
+__all__ = ["TensorPydantic"]
+
+
+def _tensor_serializer(t: Tensor) -> list[float | int] | float | int:
+    return t.tolist() if t.ndim > 0 else t.item()
+
+
+class TensorPydantic(Tensor):
+    """Patched tensor type for serialization with Pydantic."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: Type[Any], handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            lambda v: v,  # identity validator,
+            schema=core_schema.any_schema(),
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                _tensor_serializer
+            ),
+        )

--- a/src/dxtb/_src/param/thirdorder.py
+++ b/src/dxtb/_src/param/thirdorder.py
@@ -27,19 +27,21 @@ from typing import Literal, Union
 
 from pydantic import BaseModel
 
+from .tensor import TensorPydantic
+
 __all__ = ["ThirdOrderShell", "ThirdOrder"]
 
 
 class ThirdOrderShell(BaseModel):
     """Representation of shell-resolved third-order electrostatics."""
 
-    s: float
+    s: Union[float, TensorPydantic]
     """Scaling factor for s-orbitals."""
 
-    p: float
+    p: Union[float, TensorPydantic]
     """Scaling factor for p-orbitals."""
 
-    d: float
+    d: Union[float, TensorPydantic]
     """Scaling factor for d-orbitals."""
 
 

--- a/test/test_param/test_tensor.py
+++ b/test/test_param/test_tensor.py
@@ -44,8 +44,6 @@ def test_scalar_serialization() -> None:
     scalar = torch.tensor(42, device=DEVICE)
     model = Model(tensor=scalar)  # type: ignore
 
-    model = Model(tensor=scalar)  # type: ignore
-
     expected = {"tensor": int(scalar.item())}
     assert model.model_dump() == expected
 

--- a/test/test_param/test_tensor.py
+++ b/test/test_param/test_tensor.py
@@ -1,0 +1,58 @@
+# This file is part of dxtb.
+#
+# SPDX-Identifier: Apache-2.0
+# Copyright (C) 2024 Grimme Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test the tensor serialization.
+"""
+
+from __future__ import annotations
+
+import torch
+from pydantic import BaseModel
+
+from dxtb._src.param.tensor import TensorPydantic
+
+from ..conftest import DEVICE
+
+
+class Model(BaseModel):
+    tensor: TensorPydantic
+
+
+def test_array_serialization() -> None:
+    t = torch.tensor([[1, 2], [3, 4]], device=DEVICE)
+    model = Model(tensor=t)  # type: ignore
+
+    expected = {"tensor": t.tolist()}
+    assert model.model_dump() == expected
+
+
+def test_scalar_serialization() -> None:
+    scalar = torch.tensor(42, device=DEVICE)
+    model = Model(tensor=scalar)  # type: ignore
+
+    model = Model(tensor=scalar)  # type: ignore
+
+    expected = {"tensor": int(scalar.item())}
+    assert model.model_dump() == expected
+
+
+def test_grad_tensor_serialization() -> None:
+    t = torch.tensor([[1.0, 4.0]], device=DEVICE, requires_grad=True)
+    model = Model(tensor=t)  # type: ignore
+
+    expected = {"tensor": t.tolist()}
+    assert model.model_dump() == expected


### PR DESCRIPTION
- Allow tensors for all floats in the pydantic parametrization
- Serialize tensors from pydantic models
- Sync ordering between reference TOML file and written TOML files