### PR TITLE
Bug Fix: return correct number of SCF iterations

### DIFF
--- a/src/dxtb/_src/calculators/types/energy.py
+++ b/src/dxtb/_src/calculators/types/energy.py
@@ -310,7 +310,7 @@ class EnergyCalculator(BaseCalculator):
         result.potential = scf_results["potential"]
         result.scf = scf_results["energy"]
         result.fenergy = scf_results["fenergy"]
-	result.iter = scf_results["iterations"]
+        result.iter = scf_results["iterations"]
 
         scf_energy = scf_results["energy"] + scf_results["fenergy"]
         result.total += scf_energy

--- a/src/dxtb/_src/calculators/types/energy.py
+++ b/src/dxtb/_src/calculators/types/energy.py
@@ -310,6 +310,7 @@ class EnergyCalculator(BaseCalculator):
         result.potential = scf_results["potential"]
         result.scf = scf_results["energy"]
         result.fenergy = scf_results["fenergy"]
+	result.iter = scf_results["iterations"]
 
         scf_energy = scf_results["energy"] + scf_results["fenergy"]
         result.total += scf_energy


### PR DESCRIPTION
### Bug: 
`result.iter` always returns 0 after any singlepoint calculation. 

### Fix: 
Assign value from `scf_results["iterations"]` to `result.iter` in `singlepoint` method of `EnergyCalculator` 

### Info: 
- dxtb version: 0.1.1
- to reproduce: 
```
import torch
import dxtb

dd = {"dtype": torch.double, "device": torch.device("cpu")}

# LiH
numbers = torch.tensor([3, 1], device=dd["device"])
positions = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 1.5]], **dd)

# instantiate a calculator
calc = dxtb.calculators.GFN1Calculator(numbers, **dd, opts={"verbosity": 5})

# run singlepoint 
pos = positions.clone().requires_grad_(True)
result = calc.singlepoint(positions)

print("N SCF iterations from result: ", result.iter) 
```